### PR TITLE
Move serialization of result set into API

### DIFF
--- a/src/Api/EntitiesByPropertyValue.php
+++ b/src/Api/EntitiesByPropertyValue.php
@@ -50,8 +50,22 @@ class EntitiesByPropertyValue extends \ApiBase {
 		}
 
 		if ( isset( $entityIds ) ) {
-			$this->getResult()->addValue( null, 'entities', $entityIds );
+			$this->getResult()->addValue(
+				null,
+				'entities',
+				$this->serializeEntityIds( $entityIds )
+			 );
 		}
+	}
+
+	private function serializeEntityIds( $entityIds ) {
+		$formattedIds = array();
+
+		foreach ( $entityIds as $entityId ) {
+			$formattedIds[] = $entityId->getSerialization();
+		}
+
+		return $formattedIds;
 	}
 
 	/**

--- a/src/ByPropertyValueEntityFinder.php
+++ b/src/ByPropertyValueEntityFinder.php
@@ -41,14 +41,7 @@ class ByPropertyValueEntityFinder {
 			$requestArguments['limit'],
 			$requestArguments['offset']
 		);
-
-		$formattedIds = array();
-
-		foreach ( $entityIds as $entityId ) {
-			$formattedIds[] = $entityId->getSerialization();
-		}
-
-		return $formattedIds;
+		return $entityIds;
 	}
 
 	/**

--- a/tests/Unit/ByPropertyValueEntityFinderTest.php
+++ b/tests/Unit/ByPropertyValueEntityFinderTest.php
@@ -78,7 +78,7 @@ class ByPropertyValueEntityFinderTest extends \PHPUnit_Framework_TestCase {
 
 	protected function assertEntityIdsEqual( array $expected, $actual ) {
 		$this->assertInternalType( 'array', $actual );
-		$this->assertContainsOnly( 'string', $actual );
+		$this->assertContainsOnly( 'Wikibase\DataModel\Entity\ItemId', $actual );
 		$this->assertEquals( $expected, $actual );
 	}
 


### PR DESCRIPTION
The SimpleQuery special page uses ByPropertyValueEntityFinder as well, and
expects the results to not be serialized.
