### PR TITLE
Don't half-pass by reference

### DIFF
--- a/src/DIC/WikibaseQueryBuilder.php
+++ b/src/DIC/WikibaseQueryBuilder.php
@@ -18,8 +18,8 @@ class WikibaseQueryBuilder {
 
 	private $globalVars;
 
-	public function __construct( array &$globalVars ) {
-		$this->globalVars = &$globalVars;
+	public function __construct( array $globalVars ) {
+		$this->globalVars = $globalVars;
 	}
 
 	/**


### PR DESCRIPTION
PHP is pretty clever. If you omit the two `&` this doesn't necessarily mean the array is copied. If it's not touched and only read it will stay a reference and never be copied.

If you want to change the original array you need both `&`.

If you omit one `&` the array will be copied. Always. No matter if it's touched or not. Which is not what should happen with an unbounded monstrosity as the `$GLOBALS`.
