### PR TITLE
Add CLI commands for installing and uninstalling the SQLStore

### DIFF
--- a/src/Cli/SQLStoreInstallCommand.php
+++ b/src/Cli/SQLStoreInstallCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wikibase\Query\Cli;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Wikibase\QueryEngine\QueryEngineException;
+use Wikibase\QueryEngine\SQLStore\Setup\Installer;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class SQLStoreInstallCommand extends Command {
+
+	/**
+	 * @var Installer
+	 */
+	private $installer;
+
+	public function setDependencies( Installer $installer ) {
+		$this->installer = $installer;
+	}
+
+	protected function configure() {
+		$this->setName( 'sqlstore:install' );
+		$this->setDescription( 'Installs the QueryEngine SQLStore' );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$output->write( '<info>Installing the QueryEngine SQLStore... </info>' );
+
+		try {
+			$this->installer->install();
+			$output->writeln( '<info>done.</info>' );
+		}
+		catch ( QueryEngineException $ex ) {
+			$output->writeln( '<error>failed!</error>' );
+			$output->writeln( '<error>' . $ex->getMessage() . '</error>' );
+		}
+
+	}
+
+}

--- a/src/Cli/SQLStoreUninstallCommand.php
+++ b/src/Cli/SQLStoreUninstallCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wikibase\Query\Cli;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Wikibase\QueryEngine\QueryEngineException;
+use Wikibase\QueryEngine\SQLStore\Setup\Uninstaller;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class SQLStoreUninstallCommand extends Command {
+
+	/**
+	 * @var Uninstaller
+	 */
+	private $uninstaller;
+
+	public function setDependencies( Uninstaller $uninstaller ) {
+		$this->uninstaller = $uninstaller;
+	}
+
+	protected function configure() {
+		$this->setName( 'sqlstore:uninstall' );
+		$this->setDescription( 'Uninstalls the QueryEngine SQLStore' );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$output->write( '<info>Uninstalling the QueryEngine SQLStore... </info>' );
+
+		try {
+			$this->uninstaller->uninstall();
+			$output->writeln( '<info>done.</info>' );
+		}
+		catch ( QueryEngineException $ex ) {
+			$output->writeln( '<error>failed!</error>' );
+			$output->writeln( '<error>' . $ex->getMessage() . '</error>' );
+		}
+
+	}
+
+}

--- a/src/DIC/Builders/CliApplicationBuilder.php
+++ b/src/DIC/Builders/CliApplicationBuilder.php
@@ -2,10 +2,14 @@
 
 namespace Wikibase\Query\DIC\Builders;
 
+use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Application;
+use Wikibase\Query\Cli\SQLStoreInstallCommand;
+use Wikibase\Query\Cli\SQLStoreUninstallCommand;
 use Wikibase\Query\DIC\DependencyBuilder;
 use Wikibase\Query\DIC\DependencyManager;
 use Wikibase\QueryEngine\Console\DumpSqlCommand;
+use Wikibase\QueryEngine\SQLStore\SQLStore;
 
 /**
  * @licence GNU GPL v2+
@@ -48,6 +52,8 @@ class CliApplicationBuilder extends DependencyBuilder {
 
 	private function registerCommands() {
 		$this->app->add( $this->newDumpCommand() );
+		$this->app->add( $this->newInstallCommand() );
+		$this->app->add( $this->newUninstallCommand() );
 	}
 
 	private function newDumpCommand() {
@@ -56,6 +62,44 @@ class CliApplicationBuilder extends DependencyBuilder {
 			$this->dependencyManager->newObject( 'sqlStoreSchema' ),
 			$this->dependencyManager->newObject( 'connection' )->getDatabasePlatform()
 		);
+		return $command;
+	}
+
+	private function newInstallCommand() {
+		/**
+		 * @var SQLStore $queryStore
+		 */
+		$queryStore = $this->dependencyManager->newObject( 'sqlStore' );
+
+		/**
+		 * @var Connection $connection
+		 */
+		$connection = $this->dependencyManager->newObject( 'connection' );
+
+		$installer = $queryStore->newInstaller( $connection->getSchemaManager() );
+
+		$command = new SQLStoreInstallCommand();
+		$command->setDependencies( $installer );
+
+		return $command;
+	}
+
+	private function newUninstallCommand() {
+		/**
+		 * @var SQLStore $queryStore
+		 */
+		$queryStore = $this->dependencyManager->newObject( 'sqlStore' );
+
+		/**
+		 * @var Connection $connection
+		 */
+		$connection = $this->dependencyManager->newObject( 'connection' );
+
+		$uninstaller = $queryStore->newUninstaller( $connection->getSchemaManager() );
+
+		$command = new SQLStoreUninstallCommand();
+		$command->setDependencies( $uninstaller );
+
 		return $command;
 	}
 


### PR DESCRIPTION
Since we have not implemented updating from version to version in the MediaWiki updater yet, this is very useful for development work.

![cli](https://cloud.githubusercontent.com/assets/146040/3487393/1f695414-047a-11e4-8beb-587eb97a6d81.jpg)
