### PR TITLE
Set XML name for array members

### DIFF
--- a/src/Api/EntitiesByPropertyValue.php
+++ b/src/Api/EntitiesByPropertyValue.php
@@ -32,10 +32,13 @@ class EntitiesByPropertyValue extends \ApiBase {
 			);
 		}
 
+		$entities = $this->serializeEntityIds( $this->getEntityIds() );
+		$this->getResult()->setIndexedTagName( $entities, 'entity' );
+
 		$this->getResult()->addValue(
 			null,
 			'entities',
-			$this->serializeEntityIds( $this->getEntityIds() )
+			$entities
 		 );
 	}
 


### PR DESCRIPTION
This Api fails when used with format=xml, as it does not instruct the API what name should be used for each member of the array.

Use setIndexedTagName to set the members to be an 'entity' to match the outer 'entities'.
